### PR TITLE
Remove warn-error

### DIFF
--- a/OMakefile
+++ b/OMakefile
@@ -33,7 +33,7 @@ OCAMLOPTFLAGS += -g -inline 100
 .PHONY: install
 .PHONY: uninstall
 
-OCAMLFLAGS     = -g -thread -w +a-4-6-9-27..29-32..99 -warn-error +a-4-6-9-18-27-28-29..99
+OCAMLFLAGS     = -g -thread -w +a-4-6-9-27..29-32..99 -warn-error -a
 OCAMLFINDFLAGS = -syntax camlp4o -ppopt -lwt-debug
 CFLAGS         = -g -Wall -O2 -fPIC
 


### PR DESCRIPTION
You shouldn't use `-warn-error` in the release version of your software, it breaks on new versions of OCaml when the warnings evolve.
Moreover, it doesn't make sense to copy the flags from `-w` to `-warn-error`: once a warning is inactive it doesn't matter whether it is set as fatal.